### PR TITLE
Do not publish to test.pypi.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish Python distribution to PyPI and TestPyPI
+name: Publish to PyPI
 on: push
 jobs:
   build:
@@ -85,23 +85,3 @@ jobs:
           gh release upload
           '${{ github.ref_name }}' dist/**
           --repo '${{ github.repository }}'
-  publish-to-testpypi:
-    name: Publish Python distribution to TestPyPI
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/nias
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Unfortunately, automatically publishing to test.pypi.org as described in [this](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) pypa document is broken: each push needs a new version, and you cannot publish as many versions as you like (https://github.com/pypa/packaging.python.org/issues/804). Thus, the only option seems to be to disable testpypi deployment for now.